### PR TITLE
make sure specs finish executing, send a meaningful return code

### DIFF
--- a/spec/run-jasmine.js
+++ b/spec/run-jasmine.js
@@ -5,13 +5,28 @@ if (system.args.length !== 2) {
     phantom.exit(1);
 }
 
+// Check for console message indicating jasmine is finished running
+var doneRegEx = /^\d+ specs, (\d+) failure/;
+var noReallyDoneRegEx = /^Finished in \d[\d\.]* second/;
+var rc;
+
 var page = require('webpage').create();
 
 // Route "console.log()" calls from within the Page context
 // to the main Phantom context (i.e. current "this")
 
-page.onConsoleMessage = function(msg) {
+page.onConsoleMessage = function (msg) {
     system.stdout.write(msg);
+    var match = doneRegEx.exec(msg);
+    if (match) {
+        rc = match[1];
+        return;
+    }
+    match = noReallyDoneRegEx.exec(msg);
+    if (match) {
+        system.stdout.writeLine("");
+        phantom.exit(rc);
+    }
 };
 
 system.stdout.writeLine("");

--- a/spec/run-jasmine.js
+++ b/spec/run-jasmine.js
@@ -19,7 +19,7 @@ page.onConsoleMessage = function (msg) {
     system.stdout.write(msg);
     var match = doneRegEx.exec(msg);
     if (match) {
-        rc = match[1];
+        rc = match[1]==="0" ? 0 : 1;
         return;
     }
     match = noReallyDoneRegEx.exec(msg);


### PR DESCRIPTION
In trying to use this sample code in my own project, I ran into two problems that are fixed in this pull request:
- This sample code works fine for a small number of specs, but if you have many specs, the pageLoad event might fire before the specs are done running so phantomjs will exit before the specs finish. 
- I wanted to integrate this into a continuous integration process (in my case, Travis-CI). To do this I needed phantomjs to send a return code indicating success or failure. So I use a regular expression to find the number of failed specs reported and, if it's non-zero, then I return a non-zero return code.
