### PR TITLE
Early exit

### DIFF
--- a/spec/run-jasmine.js
+++ b/spec/run-jasmine.js
@@ -35,6 +35,5 @@ page.open(system.args[1], function(status){
         console.log("Couldn't load the page");
     }
     system.stdout.writeLine("");
-    phantom.exit();
 });
 


### PR DESCRIPTION
I should have included this change in the last pull request. We want to make sure phantom.exit() isn't called before the specs finish running. This won't happen in the sample code, but if you use it with something with a few hundred specs, it will happen.
